### PR TITLE
Add dark mode support (toggle + auto body class)

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -6,14 +6,30 @@ function Navbar() {
 
     useEffect(() => {
         if (typeof window !== 'undefined') {
-            const theme = localStorage.getItem('darkTheme')
+            const theme = localStorage.getItem('theme')
             if (theme) {
-                setDarkTheme(theme === 'true')
+                setDarkTheme(theme === 'dark')
+                if (theme === 'dark') {
+                    document.body.classList.add('dark')
+                } else {
+                    document.body.classList.remove('dark')
+                }
             }
-            localStorage.setItem('darkTheme', darkTheme ? 'true' : 'false')
         }
-        
-    }, [darkTheme])
+    }, [])
+
+    const toggleTheme = () => {
+        const newTheme = !darkTheme
+        setDarkTheme(newTheme)
+        if (typeof window !== 'undefined') {
+            localStorage.setItem('theme', newTheme ? 'dark' : 'light')
+            if (newTheme) {
+                document.body.classList.add('dark')
+            } else {
+                document.body.classList.remove('dark')
+            }
+        }
+    }
 
 
     return (
@@ -22,7 +38,7 @@ function Navbar() {
                 <BookIcon />
             </div>
             <div className='flex gap-8'>
-                <button onClick={() => setDarkTheme(!darkTheme)}><MoonIcon /></button>
+                <button onClick={toggleTheme}>{darkTheme ? <SunIcon /> : <MoonIcon />}</button>
             </div>
         </div>
     )

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Dark mode styles */
+body.dark {
+  @apply bg-gray-900 text-gray-100;
+}
+body {
+  @apply bg-white text-gray-900;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,21 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className} suppressHydrationWarning={true}>
+        <script dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  const theme = localStorage.getItem('theme');
+                  if (theme === 'dark') {
+                    document.body.classList.add('dark');
+                  }
+                } catch(_) {}
+              })();
+            `
+        }} />
+        {children}
+      </body>
     </html>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,6 +16,6 @@ const config: Config = {
     },
   },
   plugins: [],
-  darkMode:"selector"
+  darkMode: "class"
 };
 export default config;


### PR DESCRIPTION
- Enables dark mode via Tailwind's 'class' strategy.
- Adds CSS for body.dark and default body, supporting light/dark backgrounds.
- Updates Navbar with a dark mode toggle and icon swap, syncs with localStorage/theme.
- Sets body class on initial layout render according to localStorage.

Users can now toggle dark mode from the Navbar, and the app will remember the preference.