### PR TITLE
Remove Dark Mode from Website

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,10 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Dark mode styles */
-body.dark {
-  @apply bg-gray-900 text-gray-100;
-}
+
 body {
   @apply bg-white text-gray-900;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,18 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className} suppressHydrationWarning={true}>
-        <script dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                try {
-                  const theme = localStorage.getItem('theme');
-                  if (theme === 'dark') {
-                    document.body.classList.add('dark');
-                  }
-                } catch(_) {}
-              })();
-            `
-        }} />
+        
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export default function Home() {
   const [word, setword] = useState("");
 
   return (
-    <main className={` dark:bg-black flex gap-6 min-h-screen max-w-[900px] mx-auto flex-col items-center selection:rounded-lg selection:bg-violet-100 justify-between px-4 py-8 lg:p-24`}>
+    <main className={`flex gap-6 min-h-screen max-w-[900px] mx-auto flex-col items-center selection:rounded-lg selection:bg-violet-100 justify-between px-4 py-8 lg:p-24`}>
       <Navbar />
       <InputField setword={setword} />
       <WordInfo word={word} />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,6 +16,6 @@ const config: Config = {
     },
   },
   plugins: [],
-  darkMode: "class"
+
 };
 export default config;


### PR DESCRIPTION
This PR removes dark mode support from the website:
- Removes `darkMode: "class"` from `tailwind.config.ts`
- Deletes dark mode specific CSS from `globals.css`
- Removes the dark mode script from `layout.tsx`
- Cleans up `main` className in `page.tsx` to eliminate dark mode classes

The site now only supports light mode.