### PR TITLE
Fix TypeScript ref callback error in WordInfo component

### DIFF
--- a/app/components/WordInfo.tsx
+++ b/app/components/WordInfo.tsx
@@ -63,7 +63,7 @@ function WordInfo({ word: word }: { word: string }) {
                                         aria-label={`Play pronunciation audio ${audioIdx+1}`}
                                     >
                                         <audio
-                                            ref={el => (audioRefs.current[audioIdx] = el)}
+                                            ref={el => {audioRefs.current[audioIdx] = el;}}
                                             preload='auto'
                                             src={phon.audio}
                                             onEnded={handleAudioEnd}


### PR DESCRIPTION
This PR fixes a TypeScript compilation error in the WordInfo component where the ref callback for the audio element was incorrectly returning a value instead of void.

The error was:
```
Type '(el: HTMLAudioElement | null) => HTMLAudioElement | null' is not assignable to type 'LegacyRef<HTMLAudioElement> | undefined'.
```

The fix changes the ref callback from:
```tsx
ref={el => (audioRefs.current[audioIdx] = el)}
```
to:
```tsx
ref={el => {audioRefs.current[audioIdx] = el;}}
```

This ensures the callback function returns void, which satisfies the React ref callback type requirements.