### PR TITLE
Fix audio ref assignment to resolve TypeScript error in WordInfo component

### DIFF
--- a/app/components/WordInfo.tsx
+++ b/app/components/WordInfo.tsx
@@ -62,7 +62,7 @@ function WordInfo({ word: word }: { word: string }) {
                                         aria-label="Play pronunciation audio"
                                     >
                                         <audio
-                                            ref={el => audioRef.current = el}
+                                            ref={audioRef}
                                             preload='auto'
                                             src={phoneticsWithAudio[0].audio}
                                             onEnded={handleAudioEnd}


### PR DESCRIPTION
Replaced the audio ref assignment in the <audio> tag of the WordInfo component from an inline function to directly passing the audioRef, as required by React and TypeScript. This fixes the TypeScript error ("Type '(el: HTMLAudioElement | null) => HTMLAudioElement | null' is not assignable to type 'LegacyRef<HTMLAudioElement> | undefined'.") during compilation.

No behavioral change, only type correction to allow successful build.